### PR TITLE
disable GPG signing

### DIFF
--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -43,6 +43,9 @@ publishUtils.exec('git init');
 publishUtils.exec('git config user.name ' + JSON.stringify(config.gitUsername));
 publishUtils.exec('git config user.email ' + JSON.stringify(config.gitEmail));
 
+// disable GPG signing
+publishUtils.exec('git config commit.gpgsign false');
+
 // The first and only commit to this new Git repo contains all the
 // files present with the commit message "Deploy to GitHub Pages".
 publishUtils.exec('git add .');


### PR DESCRIPTION
was having issues with committing;

```bash
Error: Exec code(128) on executing: git commit -m "Deploy Storybook to GitHub Pages"
```

realized it was GPG blocking it, as it's a global setting for me:

```bash
error: gpg failed to sign the data
fatal: failed to write commit object
```

shouldn't be an issue if this isn't set, but as GPG becomes more popular this is a simple one-liner to prevent others from having the same issue.