### PR TITLE
add git remote option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ It will override the default configuration:
 }
 ```
 
+To deploy Storybook to a remote other than `origin`, pass a `--remote` flag to `npm run deploy-storybook`.  
+For example, to deploy to your `upstream` remote:
+
+```
+npm run deploy-storybook -- --remote=upstream
+```

--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -4,6 +4,7 @@ var shell = require('shelljs');
 var publishUtils = require('../src/utils');
 var path = require('path');
 var packageJson = require(path.resolve('./package.json'));
+var argv = require('yargs').argv;
 
 var OUTPUT_DIR = 'out' + Math.ceil(Math.random() * 9999);
 
@@ -15,9 +16,11 @@ var defaultConfig = {
 
 var config = Object.assign({}, defaultConfig, packageJson['storybook-deployer'] || defaultConfig);
 
+var GIT_REMOTE = argv['remote'] || 'origin';
+
 // get GIT url
 console.log('=> Getting the git remote URL');
-var GIT_URL = publishUtils.exec('git config --get remote.origin.url');
+var GIT_URL = publishUtils.exec(`git config --get remote.${GIT_REMOTE}.url`);
 if (!GIT_URL) {
   console.log('This project is not configured with a remote git repo');
   process.exit(-1);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/kadirahq/storybook-deployer#readme",
   "dependencies": {
     "git-url-parse": "^6.0.2",
-    "shelljs": "^0.7.0"
+    "shelljs": "^0.7.0",
+    "yargs": "^8.0.1"
   }
 }


### PR DESCRIPTION
This gives an option for which remote to deploy to.  

```shell
npm run deploy-storybook -- --remote=upstream
```

It is passed to the script instead of the package.json options because developers might have their git remotes named differently.

Addresses this issue: https://github.com/storybooks/storybook-deployer/issues/8