### PR TITLE
add the npm script option

### DIFF
--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -19,6 +19,7 @@ var config = Object.assign({}, defaultConfig, packageJson['storybook-deployer'] 
 var GIT_REMOTE = argv['remote'] || 'origin';
 var TARGET_BRANCH = argv['branch'] || "gh-pages";
 var SOURCE_BRANCH = argv['source-branch'] || 'master';
+var NPM_SCRIPT = argv['script'] || 'build-storybook';
 
 // get GIT url
 console.log('=> Getting the git remote URL');
@@ -34,8 +35,8 @@ shell.mkdir(OUTPUT_DIR);
 
 // run our compile script
 console.log('=> Building storybook');
-if (packageJson.scripts['build-storybook']) {
-  publishUtils.exec('npm run build-storybook -- -o ' + OUTPUT_DIR);
+if (packageJson.scripts[NPM_SCRIPT]) {
+  publishUtils.exec('npm run ' + NPM_SCRIPT + ' -- -o ' + OUTPUT_DIR);
 } else {
   publishUtils.exec('node ./node_modules/.bin/build-storybook -o ' + OUTPUT_DIR);
 }


### PR DESCRIPTION
The following changes will allow the consumer to override the default NPM script run for `build-storybook` if they have a different naming convention for NPM scripts. I.e. something like the following:

```
    "test:watch": "jest --watchAll",
    "storybook": "npm run storybook:run",
    "storybook:run": "start-storybook -c storybook -p 6006",
    "storybook:build": "build-storybook -c storybook -o .out",
    "storybook:deploy": "storybook-to-ghpages '--script=storybook:build'",
```

as opposed to:
```
    "test:watch": "jest --watchAll",
    "storybook": "start-storybook -c storybook -p 6006",
    "build-storybook": "build-storybook -c storybook -o .out",
    "storybook:deploy": "storybook-to-ghpages",
```

We would like to use consistent namings for these scripts..