### PR TITLE
Add missing '/' to rawgit_url when remote URL doesn't end with .git

### DIFF
--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -135,9 +135,9 @@ shell.cd('..');
 shell.rm('-rf', OUTPUT_DIR);
 
 if (TARGET_BRANCH !== 'gh-pages') {
-  const rawgit_url = GIT_URL.replace('github.com', 'rawgit.com').replace('.git', '/') +
+  const rawGitUrl = GIT_URL.replace('github.com', 'rawgit.com').replace('.git', '').replace(/\/$/ , '') + '/' +
     TARGET_BRANCH + '/index.html';
-  console.log('=> Storybook deployed to: ' + rawgit_url);
+  console.log('=> Storybook deployed to: ' + rawGitUrl);
 } else {
   console.log('=> Storybook deployed to: ' + publishUtils.getGHPagesUrl(GIT_URL));
 }


### PR DESCRIPTION
Fixes `rawgit_url`to be more flexible when user like me sets remote URL without `.git` :smile:

How to test:

- Set your remote URL in `.git/config` to NOT end with `.git`. I had this:
```
[remote "upstream"]
        url = https://github.com/patternfly/patternfly-react/
```
- run `npm run storybook:deploy -- --branch=feature-branch-storybook`

Before:
```
=> Storybook deployed to: https://rawgit.com/ZitaNemeckova/patternfly-reactfeature-branch-storybook/index.html`
```
After:
```
=> Storybook deployed to: https://rawgit.com/ZitaNemeckova/patternfly-react/feature-branch-storybook/index.html`
```

@arunoda please review, thanks 😸 