### PR TITLE
Monorepo Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm run deploy-storybook -- --existing-output-dir=.out
 
 ### Deploy a Monorepo
 
-If you manage a monorepo with multiple storybooks your can you pass the `packages` flag to `deploy-storybook` to scan a directory for `package.json`s.
+If you manage a monorepo with multiple storybooks you can you pass the `packages` flag to `deploy-storybook` to scan a directory for `package.json`s.
 
 The following command will search the `packages` directory for packages.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ If you have previously built your storybook output (through a different CI step,
 npm run deploy-storybook -- --existing-output-dir=.out
 ```
 
+### Deploy a Monorepo
+
+If you manage a monorepo with multiple storybooks your can you pass the `packages` flag to `deploy-storybook` to scan a directory for `package.json`s.
+
+The following command will search the `packages` directory for packages.
+
+```sh
+npm run deploy-storybook -- --packages packages
+```
+
 ### Deploying Storybook as part of a CI service
 
 To deploy Storybook as part of a CI step, pass the `ci` flag to `npm run deploy-storybook`.

--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -3,6 +3,7 @@
 var shell = require('shelljs');
 var publishUtils = require('../src/utils');
 var path = require('path');
+var fs = require('fs');
 var glob = require('glob');
 var packageJson = require(path.resolve('./package.json'));
 var argv = require('yargs').argv;

--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -42,9 +42,9 @@ function buildStorybook() {
   shell.mkdir(OUTPUT_DIR);
 
   if (packageJson.scripts[NPM_SCRIPT]) {
-    exec('npm run ' + NPM_SCRIPT + ' -- -o ' + OUTPUT_DIR);
+    publishUtils.exec('npm run ' + NPM_SCRIPT + ' -- -o ' + OUTPUT_DIR);
   } else {
-    exec('node ./node_modules/.bin/build-storybook -o ' + OUTPUT_DIR);
+    publishUtils.exec('node ./node_modules/.bin/build-storybook -o ' + OUTPUT_DIR);
   }
 }
 

--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -3,6 +3,7 @@
 var shell = require('shelljs');
 var publishUtils = require('../src/utils');
 var path = require('path');
+var glob = require('glob');
 var packageJson = require(path.resolve('./package.json'));
 var argv = require('yargs').argv;
 var parseRepo = require('parse-repo');
@@ -34,17 +35,57 @@ if (!GIT_URL) {
   process.exit(-1);
 }
 
-if (!SKIP_BUILD) {
+function buildStorybook() {
   // clear and re-create the out directory
   shell.rm('-rf', OUTPUT_DIR);
   shell.mkdir(OUTPUT_DIR);
 
-  // run our compile script
-  console.log('=> Building storybook');
   if (packageJson.scripts[NPM_SCRIPT]) {
-    publishUtils.exec('npm run ' + NPM_SCRIPT + ' -- -o ' + OUTPUT_DIR);
+    exec('npm run ' + NPM_SCRIPT + ' -- -o ' + OUTPUT_DIR);
   } else {
-    publishUtils.exec('node ./node_modules/.bin/build-storybook -o ' + OUTPUT_DIR);
+    exec('node ./node_modules/.bin/build-storybook -o ' + OUTPUT_DIR);
+  }
+}
+
+if (!SKIP_BUILD) {
+  if (argv.packages) {
+    var origDir = process.cwd();
+    var packages = glob
+      .sync(path.join(process.cwd(), argv.packages, '**/package.json'), {
+        ignore: '**/node_modules/**'
+      })
+      .map(json => path.dirname(json));
+
+    packages.map(dir => {
+      shell.cd(dir);
+
+      if (!fs.existsSync('package.json')) {
+        return;
+      }
+
+      const subPackage = JSON.parse(
+        fs.readFileSync(path.resolve('package.json'), 'utf8')
+      );
+
+      if (!fs.existsSync('.storybook') && !subPackage.scripts[NPM_SCRIPT]) {
+        return;
+      }
+
+      console.log(`=> Building storybook for: ${subPackage.name}`);
+      buildStorybook();
+
+      const builtStorybook = path.join(dir, OUTPUT_DIR, '*');
+      const outputPath = path.join(origDir, OUTPUT_DIR, subPackage.name);
+
+      shell.mkdir('-p', outputPath);
+      shell.cp('-r', builtStorybook, outputPath);
+      shell.rm('-rf', builtStorybook);
+    });
+
+    shell.cd(origDir);
+  } else {
+    console.log('=> Building storybook');
+    buildStorybook();
   }
 }
 

--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -1,36 +1,36 @@
 #!/usr/bin/env node
 
-var shell = require('shelljs');
-var publishUtils = require('../src/utils');
-var path = require('path');
-var fs = require('fs');
-var glob = require('glob');
-var packageJson = require(path.resolve('./package.json'));
-var argv = require('yargs').argv;
-var parseRepo = require('parse-repo');
+const shell = require('shelljs');
+const publishUtils = require('../src/utils');
+const path = require('path');
+const fs = require('fs');
+const glob = require('glob');
+const packageJson = require(path.resolve('./package.json'));
+const argv = require('yargs').argv;
+const parseRepo = require('parse-repo');
 
-var SKIP_BUILD = Boolean(argv['existing-output-dir'])
-var OUTPUT_DIR = argv['existing-output-dir'] || 'out' + Math.ceil(Math.random() * 9999);
+const SKIP_BUILD = Boolean(argv['existing-output-dir'])
+const OUTPUT_DIR = argv['existing-output-dir'] || 'out' + Math.ceil(Math.random() * 9999);
 
-var defaultConfig = {
+const defaultConfig = {
   gitUsername: 'GH Pages Bot',
   gitEmail: 'hello@ghbot.com',
   commitMessage: 'Deploy Storybook to GitHub Pages'
 };
 
-var config = Object.assign({}, defaultConfig, packageJson['storybook-deployer'] || defaultConfig);
+const config = Object.assign({}, defaultConfig, packageJson['storybook-deployer'] || defaultConfig);
 
-var GIT_REMOTE = argv['remote'] || 'origin';
-var TARGET_BRANCH = argv['branch'] || "gh-pages";
-var SOURCE_BRANCH = argv['source-branch'] || 'master';
-var NPM_SCRIPT = argv['script'] || 'build-storybook';
-var CI_DEPLOY = Boolean(argv['ci']);
-var HOST_TOKEN_ENV_VARIABLE = argv['host-token-env-variable'] || 'GH_TOKEN';
-var HOST_TOKEN = process.env[HOST_TOKEN_ENV_VARIABLE];
+const GIT_REMOTE = argv['remote'] || 'origin';
+const TARGET_BRANCH = argv['branch'] || "gh-pages";
+const SOURCE_BRANCH = argv['source-branch'] || 'master';
+const NPM_SCRIPT = argv['script'] || 'build-storybook';
+const CI_DEPLOY = Boolean(argv['ci']);
+const HOST_TOKEN_ENV_VARIABLE = argv['host-token-env-variable'] || 'GH_TOKEN';
+const HOST_TOKEN = process.env[HOST_TOKEN_ENV_VARIABLE];
 
 // get GIT url
 console.log('=> Getting the git remote URL');
-var GIT_URL = publishUtils.exec(`git config --get remote.${GIT_REMOTE}.url`);
+let GIT_URL = publishUtils.exec(`git config --get remote.${GIT_REMOTE}.url`);
 if (!GIT_URL) {
   console.log('This project is not configured with a remote git repo');
   process.exit(-1);
@@ -48,40 +48,42 @@ function buildStorybook() {
   }
 }
 
+function buildSubPackage(origDir, dir) {
+  shell.cd(dir);
+
+  if (!fs.existsSync('package.json')) {
+    return;
+  }
+
+  const subPackage = JSON.parse(
+    fs.readFileSync(path.resolve('package.json'), 'utf8')
+  );
+
+  if (!fs.existsSync('.storybook') && !subPackage.scripts[NPM_SCRIPT]) {
+    return;
+  }
+
+  console.log(`=> Building storybook for: ${subPackage.name}`);
+  buildStorybook();
+
+  const builtStorybook = path.join(dir, OUTPUT_DIR, '*');
+  const outputPath = path.join(origDir, OUTPUT_DIR, subPackage.name);
+
+  shell.mkdir('-p', outputPath);
+  shell.cp('-r', builtStorybook, outputPath);
+  shell.rm('-rf', builtStorybook);
+}
+
 if (!SKIP_BUILD) {
   if (argv.packages) {
-    var origDir = process.cwd();
-    var packages = glob
-      .sync(path.join(process.cwd(), argv.packages, '**/package.json'), {
+    const origDir = process.cwd();
+    
+    glob
+      .sync(path.join(origDir, argv.packages, '**/package.json'), {
         ignore: '**/node_modules/**'
       })
-      .map(json => path.dirname(json));
-
-    packages.map(dir => {
-      shell.cd(dir);
-
-      if (!fs.existsSync('package.json')) {
-        return;
-      }
-
-      const subPackage = JSON.parse(
-        fs.readFileSync(path.resolve('package.json'), 'utf8')
-      );
-
-      if (!fs.existsSync('.storybook') && !subPackage.scripts[NPM_SCRIPT]) {
-        return;
-      }
-
-      console.log(`=> Building storybook for: ${subPackage.name}`);
-      buildStorybook();
-
-      const builtStorybook = path.join(dir, OUTPUT_DIR, '*');
-      const outputPath = path.join(origDir, OUTPUT_DIR, subPackage.name);
-
-      shell.mkdir('-p', outputPath);
-      shell.cp('-r', builtStorybook, outputPath);
-      shell.rm('-rf', builtStorybook);
-    });
+      .map(json => path.dirname(json))
+      .map(subPackage => buildSubPackage(origDir, subPackage));
 
     shell.cd(origDir);
   } else {
@@ -112,7 +114,7 @@ publishUtils.exec('git commit -m ' + JSON.stringify(config.commitMessage));
 // /dev/null to hide any sensitive credential data that might otherwise be exposed.
 console.log('=> Deploying storybook');
 if (CI_DEPLOY) {
-  var repositoryDetails = parseRepo(GIT_URL);
+  const repositoryDetails = parseRepo(GIT_URL);
 
   if (repositoryDetails.host === 'github.com' && HOST_TOKEN) {
     GIT_URL = 'https://' + HOST_TOKEN + '@' + repositoryDetails.host + '/' + repositoryDetails.repository;
@@ -124,7 +126,7 @@ shell.cd('..');
 shell.rm('-rf', OUTPUT_DIR);
 
 if (TARGET_BRANCH !== 'gh-pages') {
-  var rawgit_url = GIT_URL.replace('github.com', 'rawgit.com').replace('.git', '/') +
+  const rawgit_url = GIT_URL.replace('github.com', 'rawgit.com').replace('.git', '/') +
     TARGET_BRANCH + '/index.html';
   console.log('=> Storybook deployed to: ' + rawgit_url);
 } else {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "git-url-parse": "^8.1.0",
+    "glob": "^7.1.3",
     "parse-repo": "^1.0.4",
     "shelljs": "^0.8.1",
     "yargs": "^11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,18 @@ glob@^7.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
Adds support for monorepos.

Accomplished by:

- Adding `packages` flag that specifies a folder that sub-packages are kept in
- Use [glob](https://www.npmjs.com/package/glob) to find all `package.json`s (excluding `node_modules`)
- Go to the directory, make sure its has a `.storybook` directory or specifies the build script and built it
- Move the built storybook to the root output directory and clean up
- Continue as normal

NOTE: I have tested this on my own monorepo storybook and it works. It is on a private Github though, so I cannot share the results.

closes #14 