### PR TITLE
Add `out` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ If you customize the build configuration with some additional params (like stati
 }
 ```
 
+### Configure Build Directory
+
+If you need to configure the output directory you can supply the `out` flag.
+
+```sh
+npm run deploy-storybook -- --out=.out
+```
+
 ### Skip Build Step
 
 If you have previously built your storybook output (through a different CI step, etc) and just need to publish it, specify the directory like this:

--- a/README.md
+++ b/README.md
@@ -28,12 +28,10 @@ If you customize the build configuration with some additional params (like stati
 ```json
 {
   "scripts": {
-    "build-storybook": "build-storybook -s public -o .out",
+    "build-storybook": "build-storybook -s public",
   }
 }
 ```
-
-> Make sure to set the output directory as **`.out`**.
 
 ### Skip Build Step
 

--- a/bin/storybook_to_ghpages
+++ b/bin/storybook_to_ghpages
@@ -8,7 +8,7 @@ var argv = require('yargs').argv;
 var parseRepo = require('parse-repo');
 
 var SKIP_BUILD = Boolean(argv['existing-output-dir'])
-var OUTPUT_DIR = argv['existing-output-dir'] || 'out' + Math.ceil(Math.random() * 9999);
+var OUTPUT_DIR = argv.out || argv['existing-output-dir'] || 'out' + Math.ceil(Math.random() * 9999);
 
 var defaultConfig = {
   gitUsername: 'GH Pages Bot',


### PR DESCRIPTION
When I deploy my storybook I also deploy a [playroom](https://github.com/seek-oss/playroom), some static files, and soon some typedocs. To do this I need to be able to configure the output directory so that all my builds go to the same place.

This PR adds and `out` flag to override the random outDir that is currently used.

closes #22 
closes #35